### PR TITLE
Add Github Actions for adding a matrix of smoke tests against glibc based new enough Linux

### DIFF
--- a/.github/workflows/push-smoketest-centos.yml
+++ b/.github/workflows/push-smoketest-centos.yml
@@ -1,0 +1,31 @@
+name: Smoketest (CentOS)
+on: push
+
+jobs:
+  smoketest-centos:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - centos:7
+          - centos:8
+        compiler:
+          - gcc
+          - clang
+
+    container:
+      image: ${{ matrix.image }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: yum install -y make glibc-devel ${{ matrix.compiler }}
+
+      - name: Make
+        env:
+          CC: ${{ matrix.compiler }}
+        run: make

--- a/.github/workflows/push-smoketest-debian.yml
+++ b/.github/workflows/push-smoketest-debian.yml
@@ -1,0 +1,37 @@
+name: Smoketest (Debian)
+on: push
+
+jobs:
+  smoketest-debian:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - debian:jessie
+          - debian:stretch
+          - debian:buster
+          - debian:bullseye
+        compiler:
+          - gcc
+          - clang
+
+    container:
+      image: ${{ matrix.image }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get update -qq
+          apt-get install -qq make ${{ matrix.compiler }}
+
+      - name: Make
+        env:
+          CC: ${{ matrix.compiler }}
+        run: make

--- a/.github/workflows/push-smoketest-ubuntu.yml
+++ b/.github/workflows/push-smoketest-ubuntu.yml
@@ -1,0 +1,40 @@
+name: Smoketest (Ubuntu)
+on: push
+
+jobs:
+  smoketest-ubuntu:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - ubuntu:14.04
+          - ubuntu:16.04
+          - ubuntu:18.04
+          - ubuntu:20.04
+          - ubuntu:20.10
+          - ubuntu:21.04
+          - ubuntu:21.10
+        compiler:
+          - gcc
+          - clang
+
+    container:
+      image: ${{ matrix.image }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get update -qq
+          apt-get install -qq make ${{ matrix.compiler }}
+
+      - name: Make
+        env:
+          CC: ${{ matrix.compiler }}
+        run: make

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC ?= gcc
-CFLAGS ?= -O3
+CFLAGS ?= -O3 -std=gnu99
 SnowFall:	SnowFall.c Makefile skein.o skein_block.o well.c
 		$(CC) $(CFLAGS) -lpthread -c -o SnowFall SnowFall.c skein.o skein_block.o
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
+CC ?= gcc
+
 SnowFall:	SnowFall.c Makefile skein.o skein_block.o well.c
-		gcc -o SnowFall -O3 SnowFall.c skein.o skein_block.o -lpthread
+		$(CC) -o SnowFall -O3 SnowFall.c skein.o skein_block.o -lpthread
 
 skein.o:	skein.c skein.h skein_port.h brg_types.h brg_endian.h skein_iv.h
-		gcc -c -O3 -o skein.o skein.c
+		$(CC) -c -O3 -o skein.o skein.c
 
 skein_block.o:	skein_block.c skein.h
-		gcc -c -O3 -o skein_block.o skein_block.c
+		$(CC) -c -O3 -o skein_block.o skein_block.c
 
 clean:
 		rm skein.o skein_block.o SnowFall

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 CC ?= gcc
-
+CFLAGS ?= -O3
 SnowFall:	SnowFall.c Makefile skein.o skein_block.o well.c
-		$(CC) -o SnowFall -O3 SnowFall.c skein.o skein_block.o -lpthread
+		$(CC) $(CFLAGS) -lpthread -c -o SnowFall SnowFall.c skein.o skein_block.o
 
 skein.o:	skein.c skein.h skein_port.h brg_types.h brg_endian.h skein_iv.h
-		$(CC) -c -O3 -o skein.o skein.c
+		$(CC) $(CFLAGS) -c -o skein.o skein.c
 
 skein_block.o:	skein_block.c skein.h
-		$(CC) -c -O3 -o skein_block.o skein_block.c
+		$(CC) $(CFLAGS) -c -o skein_block.o skein_block.c
 
 clean:
 		rm skein.o skein_block.o SnowFall


### PR DESCRIPTION
* Centos 7-8
* Ubuntu 14.04 and up
* Debian Jessie and up

As briefly discussed on Discord, Alpine is out of scope for now as your code does not run on [musl](https://musl.libc.org/).

The infrastructure at Github cannot deal with Centos 6 anymore, so that's also out of scope.

To be fair, the battery of tests this extends further back than reasonable as it is now.

I've also taken the liberty of doing the minimal modifications to your Makefile in order to be able to do an easy matrix approach to using multiple compilers per distribution and also to be able to start to matrix sweep various compilation flags later on (and/or to push for `-Werror` and friends).